### PR TITLE
changed a typo at the instructions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Put every rotating words inside the `<span class="rotate"></span>` and separate 
 ````javascript
 $(".rotate").textrotator({
   animation: "dissolve", // You can pick the way it animates when rotating through words. Options are dissolve (default), fade, flip, flipUp, flipCube, flipCubeUp and spin.
-  separator: "," // If you don't want commas to be the separator, you can define a new separator (|, &, * etc.) by yourself using this field.
+  separator: ",", // If you don't want commas to be the separator, you can define a new separator (|, &, * etc.) by yourself using this field.
   speed: 2000 // How many milliseconds until the next word show.
 });
 ````


### PR DESCRIPTION
A "," was missing at the end of the line:
separator: ","

This was causing an "unspected identifier" error
