### PR TITLE
fix speed bug when animation set as fade

### DIFF
--- a/jquery.simple-text-rotator.js
+++ b/jquery.simple-text-rotator.js
@@ -151,10 +151,10 @@
           break;
           
           case 'fade':
-            el.fadeOut(settings.speed, function() {
+            el.fadeOut(settings.speed / 2, function() {
               index = $.inArray(el.text(), array)
               if((index + 1) == array.length) index = -1
-              el.text(array[index + 1]).fadeIn(settings.speed);
+              el.text(array[index + 1]).fadeIn(settings.speed / 2);
             });
           break;
         }


### PR DESCRIPTION
say speed was set to 2000 and animation was set as fade, then we need (speed / 2) ms to fade in and the same time to fade out
